### PR TITLE
project_servicesモジュールの定義をnetworkモジュールからtier1に移動

### DIFF
--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -15,7 +15,7 @@ terraform {
       version = "3.6.0"
     }
   }
-  required_version = "1.7.4"
+  required_version = "1.7.5"
 }
 
 provider "google" {


### PR DESCRIPTION
### 概要

表題通り。
他Terraformの利用バージョンを1.7.4から1.7.5に変更。