### PR TITLE
バケットはグローバルなので環境ごとに名前変えないといけない

### DIFF
--- a/terraform/tier1-main.tf
+++ b/terraform/tier1-main.tf
@@ -46,7 +46,8 @@ module "network" {
 }
 
 module "storage" {
-  source  = "../../../modules/storage"
-  service = var.service
-  env     = var.env
+  source             = "../../../modules/storage"
+  service            = var.service
+  env                = var.env
+  sample_bucket_name = "${local.project_id}-sample-bucket"
 }


### PR DESCRIPTION
### 概要

表題通り。