### PR TITLE
Slack通知アクションの修正

### DIFF
--- a/.github/actions/slack/action.yaml
+++ b/.github/actions/slack/action.yaml
@@ -17,14 +17,39 @@ runs:
   steps:
     - name: send workflow result to slack channel
       # slackapi/slack-github-actionはコミットハッシュによる指定ができないのでバージョンで固定
-      uses: slackapi/slack-github-action@v1.25.0
+      uses: slackapi/slack-github-action@v1.26.0
       with:
         channel-id: ${{ inputs.channel_id }}
         payload: |
           {
-            "color": "${{ inputs.conclusion == 'success' && '#36a64f' || '#f26268' }}",
-            "pretext": "",
-            "text": "*[workflow]*\n${{ env.WORKFLOW }}\n\n*[title]*\n${{ env.PR_TITLE }}\n\n*[action url]*\n${{ env.ACTION_URL }}\n\n*[pull request url]*\n${{ env.PR_URL }}"
+            "attachments": [
+              {
+                "pretext": "",
+                "color": "${{ inputs.conclusion == 'success' && '36a64f' || 'f26268' }}",
+                "fields": [
+                  {
+                    "title": "Workflow",
+                    "short": true,
+                    "value": "${{ env.WORKFLOW }}"
+                  },
+                  {
+                    "title": "Action URL",
+                    "short": true,
+                    "value": "${{ env.ACTION_URL }}"
+                  },
+                  {
+                    "title": "Title",
+                    "short": true,
+                    "value": "${{ env.PR_TITLE }}"
+                  },
+                  {
+                    "title": "Pull Request URL",
+                    "short": true,
+                    "value": "${{ env.PR_URL }}"
+                  }
+                ]
+              }
+            ]
           }
       env:
         # PRタイトルなどの任意入力可能な値は、シェルやTypeScript実行ステップで参照するとインジェクション攻撃に使用されるケースがある
@@ -37,3 +62,4 @@ runs:
         PR_URL: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}
         ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         SLACK_WEBHOOK_URL: ${{ inputs.webhook_url }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ on:
 
 # ワークフローの同時実行数を1にするための設定
 # 複数のPRからterraform applyやterraform testが同時実行されないようにする
-# groupの値をstg.yamlやprod.yamlでも同じにすると、全環境で1度に1つのワークフローしか実行できなくなるで注意
+# groupの値をstg.yamlやprod.yamlでも同じにすると、全環境で1度に1つのワークフローしか実行できなくなるので注意
 # (ただしstagingのapply中にこのワークフローを実行すると、plan時にロックが取得できずにエラーが出るのでその辺りの取り扱いはポリシー次第)
 # cancel-in-progress:falseにすると既に実行済みのワークフローの実行が完了するまで、後続のワークフローは待機するようになる
 # cancel-in-progress:trueにすると既に実行済みのワークフローをキャンセルして、後続のワークフローを開始する
@@ -39,6 +39,14 @@ jobs:
         run: |
           ./scripts/check_test_matrix.sh
 
+      # environmentsやmodules配下のHCLファイルが格納されているディレクトリ全てでtflintコマンドを実行
+      - name: run TFLint
+        run: |
+          # TFLintをインストール(アクションのバージョンアップの際に忘れてはいけない)
+          # なおこのスクリプトが万が一にもGCPにアクセス出来ないよう、validationとtest-prepでジョブを分けている
+          curl -s https://raw.githubusercontent.com/terraform-linters/tflint/v0.50.3/install_linux.sh | bash
+          ./scripts/tflint.sh
+
       # terraform CLIをインストール
       - name: install terraform CLI
         uses: ./.github/actions/setup
@@ -49,14 +57,6 @@ jobs:
       - name: run terraform fmt
         run: |
           ./scripts/tffmt.sh
-
-      # environmentsやmodules配下のHCLファイルが格納されているディレクトリ全てでtflintコマンドを実行
-      - name: run TFLint
-        run: |
-          # TFLintをインストール(アクションのバージョンアップの際に忘れてはいけない)
-          # なおこのスクリプトが万が一にもGCPにアクセス出来ないよう、validationとtest-prepでジョブを分けている
-          curl -s https://raw.githubusercontent.com/terraform-linters/tflint/v0.50.3/install_linux.sh | bash
-          ./scripts/tflint.sh
 
       # environmentsやmodules配下のHCLファイルが格納されているディレクトリ全てでterraform validateコマンドを実行
       - name: run terraform validate


### PR DESCRIPTION
### 概要

SlackのIncoming Webhookがdeprecatedの状態だった。
https://api.slack.com/legacy/custom-integrations/messaging/webhooks
よってSlack appsベースのWebhookに変更したが、ペイロードや設定を修正する必要が出てきたため、このPRで対応。
ついでにセキュリティ上の理由からvalidationジョブのTFLint実行順を変更。
