### PR TITLE
Github Actionsのワークフローでworkflow_dispatchを無効化

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,9 +1,7 @@
 name: test
 
-# workflow_dispatch ... Github Actionsのコンソール上からワークフローを実行出来るようにするする設定
-# pull_request.types: [opened, synchronize] ... PR作成時、コミットプッシュ時にワークフローを実行
+# PR作成時、コミットプッシュ時にワークフローを実行
 on:
-  workflow_dispatch:
   pull_request:
     branches:
       - main


### PR DESCRIPTION
### 概要

当初の想定ではmainブランチのソースコードでtest.yamlのワークフローを実行することで、test環境のrevertなどを行えるようにするために導入したが、terraform planコマンドの実行結果を書き込む対象となるPR番号を自動的に判別するなどが困難なため無効化。

また上記用途だけならワークアラウンドはいくらでもあるためそこまでメリットがなかった。
