### PR TITLE
Conftestを導入

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# Github上でRegoのコードを表示する際にデフォルトだとインデント幅が8スペースになって見辛いので以下を設定
+# ref. https://docs.styra.com/regal/rules/style/opa-fmt#rationale
+[*.rego]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = tab
+indent_size = 2

--- a/.github/actions/slack/action.yaml
+++ b/.github/actions/slack/action.yaml
@@ -58,8 +58,8 @@ runs:
         # ちなみに上記ケースではスクリプトを実行しているわけではない気もするが念のため
         # またインジェクション攻撃ができないgithub.event.head_commit.urlなども環境変数で定義しているが統一感のため
         WORKFLOW: ${{ github.workflow }}
+        ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         PR_TITLE: ${{ github.event.pull_request.title }}
         PR_URL: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}
-        ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         SLACK_WEBHOOK_URL: ${{ inputs.webhook_url }}
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,9 @@ permissions: {}
 env:
   # v0.50.3 ref. https://github.com/terraform-linters/tflint/releases/tag/v0.50.3
   TFLINT_VERSION: e34bda7f398c139d7bc528261ee96998c10e79c8
+  OPA_VERSION: 0.64.1
+  CONFTEST_VERSION: 0.51.0
+  REGAL_VERSION: 0.21.3
 
 jobs:
   validation:
@@ -41,10 +44,56 @@ jobs:
         run: |
           ./scripts/check_test_matrix.sh
 
+      # opa CLIをインストール
+      - name: install opa CLI
+        # v2.2.0 ref. https://github.com/open-policy-agent/setup-opa/releases/tag/v2.2.0
+        uses: open-policy-agent/setup-opa@34a30e8a924d1b03ce2cf7abe97250bbb1f332b5
+        with:
+          version: ${{ env.OPA_VERSION }}
+
+      # Regoファイルのフォーマットをチェック
+      - name: run opa fmt
+        run: |
+          ./scripts/opafmt.sh
+
+      # regal CLIをインストール
+      - name: install regal CLI
+        # v1.0.0 ref. https://github.com/StyraInc/setup-regal/releases/tag/v1.0.0
+        uses: StyraInc/setup-regal@33a142b1189004e0f14bf42b15972c67eecce776
+        with:
+          version: ${{ env.REGAL_VERSION }}
+
+      # Regoファイルに対してリンタを実行
+      - name: run regal lint
+        run: |
+          ./scripts/regal.sh
+
+      # 既にインストール済みのConftestがキャッシュに存在する場合restore
+      - name: cache conftest CLI
+        id: conftest-cache
+        # v4.0.2 ref. https://github.com/actions/cache/releases/tag/v4.0.2
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: /usr/local/bin/conftest
+          key: conftest-${{ env.CONFTEST_VERSION }}
+
+      # キャッシュにConftestが存在しない場合インストール
+      - name: install conftest if the cache doesn't exist
+        if: steps.conftest-cache.outputs.cache-hit != 'true'
+        run: |
+          CONFTEST_FILE=conftest_${{ env.CONFTEST_VERSION }}_$(uname)_$(arch).tar.gz
+          wget "https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/${CONFTEST_FILE}"
+          tar xzf ${CONFTEST_FILE}
+          sudo mv conftest /usr/local/bin
+
+      # Conftestを使用してプロジェクト内の全設定ファイルの定義がポリシーに適合しているかチェック
+      - name: run conftest
+        run: |
+          ./scripts/conftest.sh
+
       # 既にインストール済みのTFLintがキャッシュに存在する場合restore
       - name: cache tflint CLI
         id: tflint-cache
-        # v4.0.2 ref. https://github.com/actions/cache/releases/tag/v4.0.2
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: |

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ terraform.rc
 # The settings below are defined by erueru-tech.
 .idea
 .DS_Store
+org-policies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 # ref. https://pre-commit.com/#plugins
 
+# 特定のhookでエラーが発生した時点でエラー終了
 fail_fast: true
 
 repos:
@@ -11,6 +12,7 @@ repos:
       - id: check-toml
       - id: check-yaml
 
+  # test
   - repo: local
     hooks:
       - id: test-matrix
@@ -19,27 +21,44 @@ repos:
         language: system
         always_run: true
 
+  # opa
+  - repo: local
+    hooks:
+      - id: opa-fmt
+        name: run opa fmt
+        entry: ./scripts/opafmt.sh
+        language: system
+        files: (\.rego)$
+      - id: regal-lint
+        name: run regal lint
+        entry: ./scripts/regal.sh
+        language: system
+        files: (\.rego)$
+      - id: conftest
+        name: run conftest
+        entry: ./scripts/conftest.sh
+        language: system
+        always_run: true
+
+  # terraform
   - repo: local
     hooks:
       - id: terraform-fmt
         name: run terraform fmt
         entry: ./scripts/tffmt.sh
         language: system
-        always_run: true
-
-  - repo: local
-    hooks:
+        files: (\.tf|\.tfvars|\.hcl)$
+        exclude: \.terraform\/.*$
       - id: tflint
         name: run tflint
         entry: ./scripts/tflint.sh
         language: system
-        always_run: true
-
-  # チェックに1分以上かかるのでCIに任せる
-  # - repo: local
-  #   hooks:
-  #     - id: terraform-validate
-  #       name: run terraform validate
-  #       entry: ./scripts/tfvalidate.sh
-  #       language: system
-  #       always_run: true
+        files: (\.tf|\.tfvars|\.hcl)$
+        exclude: \.terraform\/.*$
+      # チェックに1分以上かかるのでCIに任せる
+      # - id: terraform-validate
+      #   name: run terraform validate
+      #   entry: ./scripts/tfvalidate.sh
+      #   language: system
+      #   files: (\.tf|\.tfvars|\.hcl)$
+      #   exclude: \.terraform\/.*$

--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -1,0 +1,37 @@
+rules:
+  # Conftestによる設定ファイルのチェックではentrypointは不要
+  # ref. https://docs.styra.com/regal/rules/idiomatic/no-defined-entrypoint
+  idiomatic:
+    no-defined-entrypoint:
+      level: ignore
+  # テストコードのパッケージ名に_testを付けるメリットを開発時に感じられないためignore
+  # ref. https://docs.styra.com/regal/rules/testing/test-outside-test-package
+  testing:
+    test-outside-test-package:
+      level: ignore
+  custom:
+    # パッケージ名やルール名、関数名の命名規約を定義
+    # ref. https://docs.styra.com/regal/rules/custom/naming-convention
+    naming-convention:
+      level: error
+      conventions:
+        # パッケージ名は'conftest'から始まらなければいけない
+        - pattern: "conftest(.*)$"
+          targets:
+            - package
+        # ルール名、関数名は英小文字、数字、アンダースコアのみ利用可能
+        - pattern: "^[_a-z0-9]+$"
+          targets:
+            - rule
+            - function
+    # ワンライナーでルールを記述可能なケースで記述していない場合にerrorとなる
+    # ref. https://docs.styra.com/regal/rules/custom/one-liner-rule
+    one-liner-rule:
+      level: error
+
+# OPAのどのバージョンの構文を元にチェックを行うか指定
+# なおopaの最新バージョンを利用できるようになるまで一定のラグがある
+capabilities:
+  from:
+    engine: opa
+    version: v0.63.0

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ $ ./apply_destroy.sh destroy
 - [tfenv](https://github.com/tfutils/tfenv?tab=readme-ov-file#installation) v3.0.0
 - [TFLint](https://github.com/terraform-linters/tflint?tab=readme-ov-file#installation) 0.50.3
 - [pre-commit](https://pre-commit.com/#install) v3.7.0
+- [OPA](https://www.openpolicyagent.org/docs/latest/#1-download-opa) v0.64.1
+- [Regal](https://github.com/StyraInc/regal?tab=readme-ov-file#download-regal) v0.21.3
+- [Conftest](https://www.conftest.dev/install/) v0.51.0
 - [jq](https://github.com/jqlang/jq?tab=readme-ov-file#installation) 1.6
 - [yq](https://github.com/mikefarah/yq?tab=readme-ov-file#install) 4.43.1
 

--- a/conftest.toml
+++ b/conftest.toml
@@ -1,0 +1,9 @@
+# ポリシーファイル(Rego)がまとめられているディレクトリパス(ルートから相対パスで指定)
+# デフォルト値は"policy"
+policy = "policies"
+# FIXME dataディレクトリを実際使用することになったらアンコメント
+# Regoのプログラム内で、必要に応じて使うデータ(JSON、YAML等)がまとめられているディレクトリのパス
+#data = "policies/data"
+# ポリシーのテスト対象から除外するファイル、ディレクトリ
+# .gitや.terraformに生成されるファイルは自分で作ったファイルではないのでチェックから除外
+ignore = ".git/|.terraform/|LICENSE"

--- a/policies/conftest/terraform/tflint/.tflint.yaml
+++ b/policies/conftest/terraform/tflint/.tflint.yaml
@@ -1,0 +1,6 @@
+# test_deny_terraform_naming_convention1のテスト用
+rule:
+  - terraform_naming_convention:
+    enabled: false
+  - terraform_comment_syntax:
+    enabled: false

--- a/policies/conftest/terraform/tflint/_package.rego
+++ b/policies/conftest/terraform/tflint/_package.rego
@@ -1,0 +1,10 @@
+# METADATA
+# title: TFLintに関するルールをまとめたパッケージ
+# description: |
+#  このパッケージで定義されているルールはTFLintの設定ファイルの名前がデフォルトの.tflin.hclであることを前提としている
+# scope: package
+# organizations:
+# - erueru LLC
+package conftest.terraform.tflint
+
+import rego.v1

--- a/policies/conftest/terraform/tflint/tflint_hcl.rego
+++ b/policies/conftest/terraform/tflint/tflint_hcl.rego
@@ -1,0 +1,40 @@
+package conftest.terraform.tflint
+
+import rego.v1
+
+msg_terraform_naming_convention(rule_name) := sprintf(
+	"`%v` rule must be defined with true in .tflint.hcl",
+	[rule_name],
+)
+
+# METADATA
+# description: |
+#  .tflint.hclでterraform_naming_conventionルールが有効になっていなければいけない
+# authors:
+# - name: fittecs
+# custom:
+#  severity: MEDIUM
+deny_terraform_naming_convention contains decision if {
+	data.conftest.file.name == ".tflint.hcl"
+	not input.rule.terraform_naming_convention.enabled
+	decision := {
+		"severity": rego.metadata.rule().custom.severity,
+		"msg": msg_terraform_naming_convention("terraform_naming_convention"),
+	}
+}
+
+# METADATA
+# description: |
+#  .tflint.hclでterraform_comment_syntaxルールが有効になっていなければいけない
+# authors:
+# - name: fittecs
+# custom:
+#  severity: MEDIUM
+deny_terraform_comment_syntax contains decision if {
+	data.conftest.file.name == ".tflint.hcl"
+	not input.rule.terraform_comment_syntax.enabled
+	decision := {
+		"severity": rego.metadata.rule().custom.severity,
+		"msg": msg_terraform_naming_convention("terraform_comment_syntax"),
+	}
+}

--- a/policies/conftest/terraform/tflint/tflint_hcl_test.rego
+++ b/policies/conftest/terraform/tflint/tflint_hcl_test.rego
@@ -1,0 +1,94 @@
+package conftest.terraform.tflint
+
+import rego.v1
+
+# ファイル名が.tflint.hclではない場合ルール違反になるようなデータ構造でルールにパスする
+test_deny_terraform_naming_convention1 if {
+	cfg := parse_config_file("./.tflint.yaml")
+	count(deny_terraform_naming_convention) == 0 with input as cfg
+		with data.conftest.file.name as ".tflint.yaml"
+}
+
+# .tflint.hclにruleブロック自体定義されていない場合、ルールに違反
+test_deny_terraform_naming_convention2 if {
+	cfg := parse_config("hcl2", ``)
+	{
+		"severity": "MEDIUM",
+		"msg": msg_terraform_naming_convention("terraform_naming_convention"),
+	} in deny_terraform_naming_convention with input as cfg
+		with data.conftest.file.name as ".tflint.hcl"
+}
+
+# .tflint.hclにterraform_naming_conventionルールは定義されているが値はfalseの場合、ルールに違反
+test_deny_terraform_naming_convention3 if {
+	cfg := parse_config("hcl2", `
+		rule "terraform_naming_convention" {
+			enabled = false
+		}
+	`)
+	{
+		"severity": "MEDIUM",
+		"msg": msg_terraform_naming_convention("terraform_naming_convention"),
+	} in deny_terraform_naming_convention with input as cfg
+		with data.conftest.file.name as ".tflint.hcl"
+}
+
+# .tflint.hclにterraform_naming_conventionルールがコメントアウトされている場合、ルールに違反
+test_deny_terraform_naming_convention4 if {
+	cfg := parse_config("hcl2", `
+		# rule "terraform_naming_convention" {
+		#     enabled = true
+		# }
+	`)
+	{
+		"severity": "MEDIUM",
+		"msg": msg_terraform_naming_convention("terraform_naming_convention"),
+	} in deny_terraform_naming_convention with input as cfg
+		with data.conftest.file.name as ".tflint.hcl"
+}
+
+# .tflint.hclにterraform_naming_conventionルールが定義されていてかつ値がtrueの場合、ルールにパスする
+test_deny_terraform_naming_convention5 if {
+	cfg := parse_config("hcl2", `
+		rule "terraform_naming_convention" {
+			enabled = true
+		}
+	`)
+	count(deny_terraform_naming_convention) == 0 with input as cfg
+		with data.conftest.file.name as ".tflint.hcl"
+}
+
+# .tflint.hclにruleブロック自体定義されていない場合、terraform_comment_syntaxのルールに違反
+test_terraform_comment_syntax1 if {
+	cfg := parse_config("hcl2", ``)
+	{
+		"severity": "MEDIUM",
+		"msg": msg_terraform_naming_convention("terraform_comment_syntax"),
+	} in deny_terraform_comment_syntax with input as cfg
+		with data.conftest.file.name as ".tflint.hcl"
+}
+
+# .tflint.hclにterraform_comment_syntaxルールは定義されているが値はfalseの場合、ルールに違反
+test_terraform_comment_syntax2 if {
+	cfg := parse_config("hcl2", `
+		rule "terraform_comment_syntax" {
+			enabled = false
+		}
+	`)
+	{
+		"severity": "MEDIUM",
+		"msg": msg_terraform_naming_convention("terraform_comment_syntax"),
+	} in deny_terraform_comment_syntax with input as cfg
+		with data.conftest.file.name as ".tflint.hcl"
+}
+
+# .tflint.hclにterraform_comment_syntaxルールが定義されていてかつ値がtrueの場合、ルールにパスする
+test_terraform_comment_syntax3 if {
+	cfg := parse_config("hcl2", `
+		rule "terraform_comment_syntax" {
+			enabled = true
+		}
+	`)
+	count(deny_terraform_comment_syntax) == 0 with input as cfg
+		with data.conftest.file.name as ".tflint.hcl"
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -133,6 +133,48 @@ $ ./scripts/create_terraform_module_template.sh app
 
 テストコード実行対象モジュールを定義する [.github/data/test_matrix.yaml](../.github/data/test_matrix.yaml) が [modules](../terraform/modules/) ディレクトリと同期されている状態かチェックするスクリプトです。
 
+以下のコマンドで実行します。
+
+```bash
+$ cd /path/to/infra-testing-google-sample
+$ ./scripts/check_test_matrix.sh
+```
+
+## opafmt.sh
+
+Rego ファイルに対してフォーマットを実行するためのスクリプトです。
+
+CI 環境(Github Actions) でこのスクリプトを実行した場合、フォーマットのチェックが行われます。
+
+以下のコマンドで実行します。
+
+```bash
+$ cd /path/to/infra-testing-google-sample
+$ ./scripts/opafmt.sh
+```
+
+## regal.sh
+
+Rego ファイルに対する静的チェックを regal lint コマンドで実行するためのスクリプトです。
+
+以下のコマンドで実行します。
+
+```bash
+$ cd /path/to/infra-testing-google-sample
+$ ./scripts/regal.sh
+```
+
+## conftest.sh
+
+プロジェクト内の全設定ファイルに対してポリシーテストを実行するためのスクリプトです。
+
+以下のコマンドで実行します。
+
+```bash
+$ cd /path/to/infra-testing-google-sample
+$ ./scripts/conftest.sh
+```
+
 ## tffmt.sh
 
 全 HCL ファイルに対してフォーマットを実行するためのスクリプトです。

--- a/scripts/conftest.sh
+++ b/scripts/conftest.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -eu
+
+# テストコードを実行したのち、このプロジェクト内で定義しているポリシーを適用
+conftest verify --show-builtin-errors
+conftest test --all-namespaces .
+
+# 組織ポリシープロジェクトで定義しているポリシーを適用
+conftest pull git::https://github.com/erueru-tech/infra-policy-example.git//policy -p org-policies
+conftest test -p org-policies --all-namespaces .

--- a/scripts/opafmt.sh
+++ b/scripts/opafmt.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -eu
+
+[[ -z ${CI:-} ]] && OPT="-w" || OPT="--fail --list"
+opa fmt --v1-compatible --rego-v1 $OPT policies/

--- a/scripts/regal.sh
+++ b/scripts/regal.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eu
+
+regal lint policies/

--- a/terraform/environments/scripts/destroy.sh
+++ b/terraform/environments/scripts/destroy.sh
@@ -15,5 +15,6 @@ terraform init -backend-config="bucket=$TF_VAR_service-$TF_VAR_env-terraform" -u
 if [[ -z ${CI:-} ]]; then
   terraform destroy
 else
-  terraform destroy -auto-approve
+  echo "It doesn't allow running terraform destroy on CI/CD."
+  exit 1
 fi

--- a/terraform/modules/db/main.tf
+++ b/terraform/modules/db/main.tf
@@ -56,6 +56,5 @@ module "sql_db" {
   # なおシステムの移行などで移行後にインスタンスを削除したい場合は、この値をfalseにしてから削除する流れになると思われる
   deletion_protection         = var.deletion_protection
   deletion_protection_enabled = var.deletion_protection
-  # 作成に20分以上かかるケースがあり、デフォルトの30mだと不足するケースが発生しそうであるため
-  create_timeout = "60m"
+  create_timeout              = "60m"
 }


### PR DESCRIPTION
### 概要

以下を対応。

- RegoおよびConftestによるポリシーテストの開発、実行環境構築
- 組織の[ポリシーリポジトリ](https://github.com/erueru-tech/infra-policy-example)からポリシーをダウンロードして、このプロジェクト内のほぼ全ファイルに対してポリシーテストを実行する機能追加
- pre-commitのリファクタリングおよびterraform関連で無駄な発火が発生していたのを修正
- CI/CD上でterraform destroyコマンドを実行できないように修正
