### PR TITLE
Trivy導入

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,7 @@ env:
   OPA_VERSION: 0.64.1
   CONFTEST_VERSION: 0.51.0
   REGAL_VERSION: 0.21.3
+  TRIVY_VERSION: 0.51.1
 
 jobs:
   validation:
@@ -113,6 +114,25 @@ jobs:
       - name: run tflint
         run: |
           ./scripts/tflint.sh
+
+      # 既にインストール済みのTtrivyがキャッシュに存在する場合restore
+      - name: cache trivy CLI
+        id: trivy-cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: |
+            /usr/local/bin/trivy
+          key: trivy-${{ env.TRIVY_VERSION }}
+
+      # キャッシュにTrivyが存在しない場合インストール
+      - name: install trivy if the cache doesn't exist
+        run: |
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v${{ env.TRIVY_VERSION }}
+
+      # Trivyによるセキュリティスキャンを実行
+      - name: run trivy
+        run: |
+          ./scripts/trivy.sh
 
       # terraform CLIをインストール
       - name: install terraform CLI

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,3 +62,13 @@ repos:
       #   language: system
       #   files: (\.tf|\.tfvars|\.hcl)$
       #   exclude: \.terraform\/.*$
+
+  # trivy
+  - repo: local
+    hooks:
+      # 脆弱性DBのアップデートなどが発生する場合、チェックに時間がかかるので必要に応じてCIに任せる
+      - id: trivy
+        name: run trivy
+        entry: ./scripts/trivy.sh
+        language: system
+        always_run: true

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,9 @@
+# avd-gcp-0001を除外したい場合、大文字でAVD-GCP-0001と指定しないと除外できない
+# コードに`#trivy:ignore`コメントを追加することでも特定のルールチェックを行わないようにすることが可能
+misconfigurations:
+
+secrets:
+
+vulnerabilities:
+
+licenses:

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ $ ./apply_destroy.sh destroy
 - [OPA](https://www.openpolicyagent.org/docs/latest/#1-download-opa) v0.64.1
 - [Regal](https://github.com/StyraInc/regal?tab=readme-ov-file#download-regal) v0.21.3
 - [Conftest](https://www.conftest.dev/install/) v0.51.0
+- [Trivy](https://aquasecurity.github.io/trivy/latest/getting-started/installation/) v0.51.1
 - [jq](https://github.com/jqlang/jq?tab=readme-ov-file#installation) 1.6
 - [yq](https://github.com/mikefarah/yq?tab=readme-ov-file#install) 4.43.1
 

--- a/conftest.toml
+++ b/conftest.toml
@@ -1,9 +1,6 @@
 # ポリシーファイル(Rego)がまとめられているディレクトリパス(ルートから相対パスで指定)
 # デフォルト値は"policy"
-policy = "policies"
-# FIXME dataディレクトリを実際使用することになったらアンコメント
-# Regoのプログラム内で、必要に応じて使うデータ(JSON、YAML等)がまとめられているディレクトリのパス
-#data = "policies/data"
+policy = "policies/conftest"
 # ポリシーのテスト対象から除外するファイル、ディレクトリ
 # .gitや.terraformに生成されるファイルは自分で作ったファイルではないのでチェックから除外
 ignore = ".git/|.terraform/|LICENSE"

--- a/scripts/conftest.sh
+++ b/scripts/conftest.sh
@@ -7,5 +7,7 @@ conftest verify --show-builtin-errors
 conftest test --all-namespaces .
 
 # 組織ポリシープロジェクトで定義しているポリシーを適用
+# infra-policy-exampleプロジェクトのpolicyディレクトリにはconftest以外にもポリシー用ディレクトリが存在することが想定されるため
+# 以下のようにconftestディレクトリ配下のポリシーのみを実行している
 conftest pull git::https://github.com/erueru-tech/infra-policy-example.git//policy -p org-policies
-conftest test -p org-policies --all-namespaces .
+conftest test -p org-policies/conftest --all-namespaces .

--- a/scripts/trivy.sh
+++ b/scripts/trivy.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eu
+
+trivy fs ./

--- a/trivy-secret.yaml
+++ b/trivy-secret.yaml
@@ -1,0 +1,8 @@
+# デフォルトの設定だとSecret情報がMarkDownファイルに含まれている場合でもエラーが発生しないといった挙動になる
+# 以下のように設定することで、より厳密なSecret情報の混入チェックが可能となる
+# ref. https://aquasecurity.github.io/trivy/latest/docs/scanner/secret/
+# ref. https://github.com/aquasecurity/trivy/blob/main/pkg/fanal/secret/builtin-allow-rules.go
+disable-allow-rules:
+  - markdown
+  - tests
+  - examples

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,21 @@
+# ref. https://aquasecurity.github.io/trivy/v0.51/docs/references/configuration/config-file/
+
+# Report Options #
+# Trivyで問題を検知した場合にエラー終了させるための設定
+exit-code: 1
+# デフォルトは.trivyignoreだが、YAMLフォーマットで定義できるように変更
+ignorefile: .trivyignore.yaml
+
+# Scan Options #
+scan:
+  # terraform init実行時にダウンロードされるモジュールはスキャンしないようにする設定
+  # ref. https://aquasecurity.github.io/trivy/v0.51/docs/configuration/skipping/
+  skip-dirs:
+    - "**/.terraform"
+  # 基本的なスキャン機能をすべて使用
+  # ref. https://aquasecurity.github.io/trivy/v0.51/docs/scanner/vulnerability/
+  scanners:
+    - vuln
+    - misconfig
+    - secret
+    - license


### PR DESCRIPTION
### 概要

以下を対応。

- Trivyのセキュリティスキャンを導入
- [infra-policy-example](https://github.com/erueru-tech/infra-policy-example)からダウンロードしてきたポリシーテストについて、Conftestのポリシーのみ実行するようにコマンドを修正
